### PR TITLE
feat/kakao 인증

### DIFF
--- a/backend/src/main/java/com/example/rabbithell/config/CookieUtils.java
+++ b/backend/src/main/java/com/example/rabbithell/config/CookieUtils.java
@@ -1,0 +1,69 @@
+package com.example.rabbithell.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.Optional;
+
+public class CookieUtils {
+
+	private static final ObjectMapper objectMapper = new ObjectMapper()
+		.findAndRegisterModules()
+		.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING)
+		.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+	public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+		if (request.getCookies() == null) return Optional.empty();
+
+		for (Cookie cookie : request.getCookies()) {
+			if (cookie.getName().equals(name)) {
+				return Optional.of(cookie);
+			}
+		}
+
+		return Optional.empty();
+	}
+
+	public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+		Cookie cookie = new Cookie(name, value);
+		cookie.setPath("/");
+		cookie.setHttpOnly(false);
+		cookie.setMaxAge(maxAge);
+		response.addCookie(cookie);
+	}
+
+	public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+		if (request.getCookies() == null) return;
+
+		for (Cookie cookie : request.getCookies()) {
+			if (cookie.getName().equals(name)) {
+				Cookie deleted = new Cookie(name, null);
+				deleted.setPath("/");
+				deleted.setMaxAge(0);
+				response.addCookie(deleted);
+			}
+		}
+	}
+
+	public static String serialize(Object obj) {
+		try {
+			return Base64.getUrlEncoder().encodeToString(objectMapper.writeValueAsBytes(obj));
+		} catch (Exception e) {
+			throw new RuntimeException("쿠키 직렬화 실패", e);
+		}
+	}
+
+	public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+		try {
+			byte[] decoded = Base64.getUrlDecoder().decode(cookie.getValue());
+			return objectMapper.readValue(decoded, cls);
+		} catch (IOException e) {
+			throw new RuntimeException("쿠키 역직렬화 실패", e);
+		}
+	}
+}

--- a/backend/src/main/java/com/example/rabbithell/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/rabbithell/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.example.rabbithell.config;
 
+import java.util.Arrays;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -8,11 +10,19 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.example.rabbithell.infrastructure.security.jwt.JwtAuthenticationFilter;
+import com.example.rabbithell.infrastructure.security.oauth.HttpCookieOAuth2AuthorizationRequestRepository;
+import com.example.rabbithell.infrastructure.security.oauth.handler.OAuth2AuthenticationSuccessHandler;
+import com.example.rabbithell.infrastructure.security.oauth.service.CustomOAuth2UserService;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 
+import jakarta.servlet.http.Cookie;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -22,30 +32,53 @@ import lombok.RequiredArgsConstructor;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final CustomOAuth2UserService customOAuth2UserService;
+	private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+	private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+	private final ClientRegistrationRepository clientRegistrationRepository;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-        http
-            .csrf(csrf -> csrf.disable())
-            .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-            .authorizeHttpRequests(auth -> auth
-                .requestMatchers(
-                    "/auth/**",
+		http
+			.csrf(csrf -> csrf.disable())
+			.sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers(
+					"/auth/**",
 					"/oauth2/**",
-					"/oauth2/authorization/**",
 					"/swagger-ui/**",
-                    "/v3/api-docs/**"
-                ).permitAll()
-                .anyRequest().authenticated()
-            )
-			.oauth2Login(oauth -> oauth
-				.loginPage("/oauth2/authorization/kakao")
+					"/v3/api-docs/**"
+				).permitAll()
+				.anyRequest().authenticated()
 			)
-            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+			.oauth2Login(oauth -> oauth
+				.authorizationEndpoint(auth -> auth
+					.authorizationRequestRepository(httpCookieOAuth2AuthorizationRequestRepository)
+				)
+				.userInfoEndpoint(userInfo -> userInfo
+					.userService(customOAuth2UserService))
+				.successHandler(oAuth2AuthenticationSuccessHandler)
+				.failureHandler((req, res, ex) -> {
+					Cookie[] cookies = req.getCookies();
+					if (cookies != null && Arrays.stream(cookies)
+						.anyMatch(cookie -> cookie.getName().equals("OAUTH2_FAILED"))) {
+						res.setStatus(429);
+						return;
+					}
 
-        return http.build();
+					Cookie failFlag = new Cookie("OAUTH2_FAILED", "true");
+					failFlag.setMaxAge(60);
+					failFlag.setPath("/");
+					res.addCookie(failFlag);
 
+					httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequest(req, res);
+					res.sendRedirect("http://localhost:8080/login-failed");
+				})
+			)
+			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+		return http.build();
     }
 
     @Bean

--- a/backend/src/main/java/com/example/rabbithell/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/auth/controller/AuthController.java
@@ -3,19 +3,24 @@ package com.example.rabbithell.domain.auth.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.rabbithell.common.response.CommonResponse;
 import com.example.rabbithell.domain.auth.domain.AuthUser;
+import com.example.rabbithell.domain.auth.domain.MiniAuthUser;
+import com.example.rabbithell.domain.auth.dto.request.FullJwtRequest;
 import com.example.rabbithell.domain.auth.dto.request.LoginRequest;
 import com.example.rabbithell.domain.auth.dto.request.SignupRequest;
 import com.example.rabbithell.domain.auth.dto.response.LoginResponse;
 import com.example.rabbithell.domain.auth.dto.response.TokenResponse;
 import com.example.rabbithell.domain.auth.service.AuthService;
+import com.example.rabbithell.domain.auth.service.TokenService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,6 +30,30 @@ import lombok.RequiredArgsConstructor;
 public class AuthController {
 
 	private final AuthService authService;
+	private final TokenService tokenService;
+
+	@GetMapping("/login-failed")
+	@ResponseBody
+	public String loginFailed() {
+		System.out.println("카카오 로그인 실패, 잠시 후 다시 시도해주세요.");
+		return "카카오 로그인 실패, 잠시 후 다시 시도해주세요.";
+	}
+
+	@PostMapping("/token/full")
+	public ResponseEntity<CommonResponse<TokenResponse>> createFullToken(
+		@AuthenticationPrincipal MiniAuthUser authUser,
+		@RequestBody FullJwtRequest request
+	) {
+		TokenResponse tokenResponse = tokenService.createFullToken(
+			authUser.getUserId(),
+			request.nickname(),
+			request.cloverName()
+		);
+
+		return ResponseEntity.ok(
+			CommonResponse.of(true, HttpStatus.OK.value(), "Full JWT 발급 성공", tokenResponse)
+		);
+	}
 
 	@PostMapping("/signup")
 	public ResponseEntity<CommonResponse<Void>> signup(@RequestBody SignupRequest request) {

--- a/backend/src/main/java/com/example/rabbithell/domain/auth/domain/MiniAuthUser.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/auth/domain/MiniAuthUser.java
@@ -1,0 +1,57 @@
+package com.example.rabbithell.domain.auth.domain;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import lombok.Getter;
+
+@Getter
+public class MiniAuthUser implements UserDetails {
+
+	private final Long userId;
+	private final String role;
+
+	public MiniAuthUser(Long userId, String role) {
+		this.userId = userId;
+		this.role = role;
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return List.of(new SimpleGrantedAuthority("ROLE_" + role));
+	}
+
+	@Override
+	public String getPassword() {
+		return null;
+	}
+
+	@Override
+	public String getUsername() {
+		return String.valueOf(userId);
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+}

--- a/backend/src/main/java/com/example/rabbithell/domain/auth/dto/request/FullJwtRequest.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/auth/dto/request/FullJwtRequest.java
@@ -1,0 +1,7 @@
+package com.example.rabbithell.domain.auth.dto.request;
+
+public record FullJwtRequest(
+	String nickname,
+	String cloverName
+) {
+}

--- a/backend/src/main/java/com/example/rabbithell/domain/auth/dto/request/SignupRequest.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/auth/dto/request/SignupRequest.java
@@ -5,6 +5,6 @@ public record SignupRequest(
 	String name,
 	String password,
 	String role,
-	String CloverName
+	String cloverName
 ) {
 }

--- a/backend/src/main/java/com/example/rabbithell/domain/auth/exception/code/AuthExceptionCode.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/auth/exception/code/AuthExceptionCode.java
@@ -12,7 +12,7 @@ public enum AuthExceptionCode {
 	USER_NOT_FOUND(false, HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
 	USER_MISS_MATCH(false, HttpStatus.BAD_REQUEST, "작성자와 요청자가 다릅니다."),
 	DUPLICATED_EMAIL(false, HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
-	DUPLICATED_Clover_NAME(false, HttpStatus.CONFLICT, "이미 사용 중인 원정대 명입니다."),
+	DUPLICATED_CLOVER_NAME(false, HttpStatus.CONFLICT, "이미 사용 중인 원정대명입니다."),
 	INVALID_PASSWORD(false, HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
 	INVALID_REFRESH_TOKEN(false, HttpStatus.BAD_REQUEST, "유효하지 않은 리프레시 토큰입니다."),
 	REFRESH_TOKEN_NOT_FOUND(false, HttpStatus.NOT_FOUND, "리프레시 토큰이 존재하지 않습니다."),

--- a/backend/src/main/java/com/example/rabbithell/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/auth/service/AuthService.java
@@ -39,9 +39,7 @@ public class AuthService {
             throw new AuthException(DUPLICATED_EMAIL);
         }
 
-		if (cloverRepository.existsByName(request.CloverName())) {
-			throw new AuthException(DUPLICATED_Clover_NAME);
-		}
+		cloverRepository.validateNameIsUnique(request.name());
 
         User user = User.builder()
             .email(request.email())
@@ -53,8 +51,8 @@ public class AuthService {
 
         User savedUser = userRepository.save(user);
 
-		Clover Clover = new Clover(request.CloverName(), savedUser);
-		cloverRepository.save(Clover);
+		Clover clover = new Clover(request.cloverName(), savedUser);
+		cloverRepository.save(clover);
 
         Inventory inventory = Inventory.builder()
             .user(savedUser)

--- a/backend/src/main/java/com/example/rabbithell/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.example.rabbithell.domain.auth.service;
 
 import static com.example.rabbithell.domain.auth.exception.code.AuthExceptionCode.*;
+import static com.example.rabbithell.domain.clover.exception.code.CloverExceptionCode.DUPLICATED_CLOVER_NAME;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -11,6 +12,7 @@ import com.example.rabbithell.domain.auth.dto.response.LoginResponse;
 import com.example.rabbithell.domain.auth.dto.response.TokenResponse;
 import com.example.rabbithell.domain.auth.exception.AuthException;
 import com.example.rabbithell.domain.clover.entity.Clover;
+import com.example.rabbithell.domain.clover.exception.CloverException;
 import com.example.rabbithell.domain.clover.repository.CloverRepository;
 import com.example.rabbithell.domain.inventory.entity.Inventory;
 import com.example.rabbithell.domain.inventory.repository.InventoryRepository;
@@ -39,7 +41,9 @@ public class AuthService {
             throw new AuthException(DUPLICATED_EMAIL);
         }
 
-		cloverRepository.validateNameIsUnique(request.name());
+		if (cloverRepository.existsByName(request.name())) {
+			throw new CloverException(DUPLICATED_CLOVER_NAME);
+		}
 
         User user = User.builder()
             .email(request.email())

--- a/backend/src/main/java/com/example/rabbithell/domain/auth/service/TokenService.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/auth/service/TokenService.java
@@ -1,0 +1,42 @@
+package com.example.rabbithell.domain.auth.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.rabbithell.domain.clover.entity.Clover;
+import com.example.rabbithell.domain.clover.repository.CloverRepository;
+import com.example.rabbithell.domain.user.model.User;
+import com.example.rabbithell.domain.user.repository.UserRepository;
+import com.example.rabbithell.infrastructure.security.jwt.JwtUtil;
+import com.example.rabbithell.domain.auth.dto.response.TokenResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+	private final CloverRepository cloverRepository;
+	private final JwtUtil jwtUtil;
+	private final UserRepository userRepository;
+
+	@Transactional
+	public TokenResponse createFullToken(Long userId, String nickname, String cloverName) {
+
+		User user = userRepository.findByIdOrElseThrow(userId);
+
+		user.updateNickname(nickname);
+		userRepository.save(user);
+
+		Clover clover = Clover.builder()
+			.user(user)
+			.name(cloverName)
+			.build();
+		cloverRepository.save(clover);
+
+		String accessToken = jwtUtil.generateAccessToken(user.getId().toString(), "USER", clover.getId(), clover.getName());
+		String refreshToken = jwtUtil.generateRefreshToken(user.getId().toString());
+
+		return new TokenResponse(accessToken, refreshToken);
+	}
+}

--- a/backend/src/main/java/com/example/rabbithell/domain/clover/entity/Clover.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/clover/entity/Clover.java
@@ -1,13 +1,17 @@
 package com.example.rabbithell.domain.clover.entity;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import com.example.rabbithell.common.audit.BaseEntity;
 import com.example.rabbithell.domain.battle.type.BattleFieldType;
+import com.example.rabbithell.domain.character.entity.Character;
 import com.example.rabbithell.domain.user.model.User;
 import com.example.rabbithell.domain.village.entity.Village;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
@@ -19,14 +23,16 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "Clovers")
+@Table(name = "clovers")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Clover extends BaseEntity {
@@ -42,14 +48,8 @@ public class Clover extends BaseEntity {
 	@JoinColumn(name = "user_id", nullable = false, unique = true)
 	private User user;
 
-	// todo 캐릭터 쪽에
-	// @ManyToOne(fetch = FetchType.LAZY)
-	// @JoinColumn(name = "Clover_id")
-	// private Clover Clover;
-
-	// 추가 후 주석 풀것
 	// @OneToMany(mappedBy = "Clover", cascade = CascadeType.ALL, orphanRemoval = true)
-	// private final List<com.example.rabbithell.domain.character.entity.Character> members = new ArrayList<>();
+	// private final List<Character> members = new ArrayList<>();
 
 	@Column(nullable = false)
 	private long cash = 0;
@@ -70,6 +70,17 @@ public class Clover extends BaseEntity {
 	)
 	@Column(name = "rare_map_type")
 	private Set<BattleFieldType> unlockedRareMaps = new HashSet<>();
+
+	@Builder
+	public Clover(String name, User user, long cash, long saving, Long currentVillage,
+		Set<BattleFieldType> unlockedRareMaps) {
+		this.name = name;
+		this.user = user;
+		this.cash = cash;
+		this.saving = saving;
+		this.currentVillage = currentVillage;
+		this.unlockedRareMaps = unlockedRareMaps;
+	}
 
 	// 레어맵 컬럼에 추가
 	public void unlockRareMap(BattleFieldType rareMap) {
@@ -142,22 +153,11 @@ public class Clover extends BaseEntity {
 		this.cash += amount;
 	}
 
-
 	// public void addMember(Character character) {
 	// 	if (members.size() >= 4) {
 	// 		throw new IllegalStateException("원정대에는 4명까지만 추가할 수 있습니다.");
 	// 	}
 	// 	this.members.add(character);
-	// 	// todo 캐릭터 생성 파트에 요청 필요
-	// 	// character.setClover(this);
-	//
-	// 	// @ManyToOne(fetch = FetchType.LAZY)
-	// 	// @JoinColumn(name = "Clover_id")
-	// 	// private Clover Clover;
-	// 	//
-	// 	// public void setClover(Clover Clover) {
-	// 	// 	this.Clover = Clover;
-	// 	// }
 	// }
 	//
 	// public boolean isFull() {

--- a/backend/src/main/java/com/example/rabbithell/domain/clover/exception/code/CloverExceptionCode.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/clover/exception/code/CloverExceptionCode.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum CloverExceptionCode {
 	ERROR_CODE_NAME(false, HttpStatus.NOT_FOUND, "에러 메시지"),
-	Clover_NOT_FOUND(false, HttpStatus.NOT_FOUND, "원정대를 찾을 수 없습니다.");
+	CLOVER_NOT_FOUND(false, HttpStatus.NOT_FOUND, "원정대를 찾을 수 없습니다."),
+	DUPLICATED_CLOVER_NAME(false, HttpStatus.NOT_FOUND, "이미 사용 중인 원정대명 입니다.");
 
 	private final boolean success;
 	private final HttpStatus status;

--- a/backend/src/main/java/com/example/rabbithell/domain/clover/repository/CloverRepository.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/clover/repository/CloverRepository.java
@@ -1,6 +1,7 @@
 package com.example.rabbithell.domain.clover.repository;
 
 import static com.example.rabbithell.domain.clover.exception.code.CloverExceptionCode.*;
+import static com.example.rabbithell.domain.clover.exception.code.CloverExceptionCode.DUPLICATED_CLOVER_NAME;
 
 import java.util.Optional;
 
@@ -17,7 +18,13 @@ public interface CloverRepository extends JpaRepository<Clover, Long> {
 
 	default Clover findByUserIdOrElseThrow(Long userId) {
 		return findByUserId(userId)
-			.orElseThrow(() -> new CloverException(Clover_NOT_FOUND));
+			.orElseThrow(() -> new CloverException(CLOVER_NOT_FOUND));
+	}
+
+	default void validateNameIsUnique(String name) {
+		if (existsByName(name)) {
+			throw new CloverException(DUPLICATED_CLOVER_NAME);
+		}
 	}
 
 }

--- a/backend/src/main/java/com/example/rabbithell/domain/clover/repository/CloverRepository.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/clover/repository/CloverRepository.java
@@ -1,7 +1,6 @@
 package com.example.rabbithell.domain.clover.repository;
 
 import static com.example.rabbithell.domain.clover.exception.code.CloverExceptionCode.*;
-import static com.example.rabbithell.domain.clover.exception.code.CloverExceptionCode.DUPLICATED_CLOVER_NAME;
 
 import java.util.Optional;
 
@@ -12,6 +11,8 @@ import com.example.rabbithell.domain.clover.exception.CloverException;
 
 public interface CloverRepository extends JpaRepository<Clover, Long> {
 
+	boolean existsByUserId(Long id);
+
 	Optional<Clover> findByUserId(Long userId);
 
 	boolean existsByName(String name);
@@ -19,12 +20,6 @@ public interface CloverRepository extends JpaRepository<Clover, Long> {
 	default Clover findByUserIdOrElseThrow(Long userId) {
 		return findByUserId(userId)
 			.orElseThrow(() -> new CloverException(CLOVER_NOT_FOUND));
-	}
-
-	default void validateNameIsUnique(String name) {
-		if (existsByName(name)) {
-			throw new CloverException(DUPLICATED_CLOVER_NAME);
-		}
 	}
 
 }

--- a/backend/src/main/java/com/example/rabbithell/domain/community/post/service/PostServiceImpl.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/community/post/service/PostServiceImpl.java
@@ -1,7 +1,5 @@
 package com.example.rabbithell.domain.community.post.service;
 
-import static com.example.rabbithell.domain.community.post.exception.code.PostExceptionCode.*;
-
 import java.util.List;
 
 import org.springframework.data.domain.Page;

--- a/backend/src/main/java/com/example/rabbithell/domain/user/model/User.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/user/model/User.java
@@ -17,9 +17,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Builder
+@NoArgsConstructor
 public class User extends BaseEntity {
 
 	@Id
@@ -39,9 +37,17 @@ public class User extends BaseEntity {
 	@Column(nullable = false)
 	private Role role;
 
-	@Builder.Default
 	@Column(nullable = false)
 	private boolean isDeleted = false;
+
+	@Builder
+	public User(String name, String email, String password, Role role, boolean isDeleted) {
+		this.name = name;
+		this.email = email;
+		this.password = password;
+		this.role = role;
+		this.isDeleted = isDeleted;
+	}
 
 	public enum Role {
 		USER, ADMIN
@@ -49,5 +55,9 @@ public class User extends BaseEntity {
 
 	public void markAsDeleted() {
 		this.isDeleted = true;
+	}
+
+	public void updateNickname(String nickname) {
+		this.name = nickname;
 	}
 }

--- a/backend/src/main/java/com/example/rabbithell/infrastructure/security/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/rabbithell/infrastructure/security/jwt/JwtAuthenticationFilter.java
@@ -10,6 +10,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.example.rabbithell.domain.auth.domain.AuthUser;
+import com.example.rabbithell.domain.auth.domain.MiniAuthUser;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -29,25 +30,34 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
         throws ServletException, IOException {
 
-        String token = resolveToken(request);
+		String token = resolveToken(request);
 
-        if (StringUtils.hasText(token) && jwtUtil.validateToken(token)) {
-            Long userId = Long.parseLong(jwtUtil.extractSubject(token));
-            String role = jwtUtil.extractRole(token);
-			Long cloverId = jwtUtil.extractCloverId(token);
-			String CloverName = jwtUtil.extractCloverName(token);
+		if (StringUtils.hasText(token) && jwtUtil.validateToken(token)) {
+			Long userId = Long.parseLong(jwtUtil.extractSubject(token));
+			String role = jwtUtil.extractRole(token);
 
-            AuthUser authUser = new AuthUser(userId, role, cloverId, CloverName);
+			// 미니 토큰 구간
+			if (!jwtUtil.hasCloverInfo(token)) {
+				MiniAuthUser authUser = new MiniAuthUser(userId, role);
+				UsernamePasswordAuthenticationToken authentication =
+					new UsernamePasswordAuthenticationToken(authUser, null, authUser.getAuthorities());
+				authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+				SecurityContextHolder.getContext().setAuthentication(authentication);
 
-            UsernamePasswordAuthenticationToken authentication =
-                new UsernamePasswordAuthenticationToken(authUser, null, authUser.getAuthorities());
+			// 풀 토큰 구간
+			} else {
+				Long cloverId = jwtUtil.extractCloverId(token);
+				String cloverName = jwtUtil.extractCloverName(token);
+				AuthUser authUser = new AuthUser(userId, role, cloverId, cloverName);
+				UsernamePasswordAuthenticationToken authentication =
+					new UsernamePasswordAuthenticationToken(authUser, null, authUser.getAuthorities());
+				authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+				SecurityContextHolder.getContext().setAuthentication(authentication);
+			}
+		}
 
-            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-        }
-
-        filterChain.doFilter(request, response);
-    }
+		filterChain.doFilter(request, response);
+	}
 
     private String resolveToken(HttpServletRequest request) {
         String bearer = request.getHeader("Authorization");

--- a/backend/src/main/java/com/example/rabbithell/infrastructure/security/jwt/JwtUtil.java
+++ b/backend/src/main/java/com/example/rabbithell/infrastructure/security/jwt/JwtUtil.java
@@ -2,10 +2,12 @@ package com.example.rabbithell.infrastructure.security.jwt;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
+import java.time.Duration;
 import java.util.Date;
 
 import org.springframework.stereotype.Component;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -25,12 +27,34 @@ public class JwtUtil {
         this.key = Keys.hmacShaKeyFor(properties.getSecret().getBytes(StandardCharsets.UTF_8));
     }
 
-    public String generateAccessToken(String userId, String role, Long CloverId, String CloverName) {
+	public boolean hasCloverInfo(String token) {
+		Claims claims = parseClaims(token);
+		return claims.get("cloverId") != null && claims.get("cloverName") != null;
+	}
+
+	public String createMiniToken(Long userId, String role) {
+		Date now = new Date();
+		long duration = role.equals("ADMIN")
+			? Duration.ofHours(12).toMillis() //어드민의 경우 12시간 사용
+			: Duration.ofMinutes(5).toMillis(); // USER의 경우 5분 사용 가능
+
+		Date expiry = new Date(now.getTime() + duration);
+
+		return Jwts.builder()
+			.setSubject(String.valueOf(userId))
+			.claim("role", role)
+			.setIssuedAt(now)
+			.setExpiration(expiry)
+			.signWith(key, SignatureAlgorithm.HS512)
+			.compact();
+	}
+
+    public String generateAccessToken(String userId, String role, Long cloverId, String cloverName) {
         return Jwts.builder()
             .setSubject(userId)
             .claim("role", role)
-			.claim("CloverId", CloverId)
-			.claim("CloverName", CloverName)
+			.claim("cloverId", cloverId)
+			.claim("cloverName", cloverName)
             .setIssuedAt(new Date())
             .setExpiration(new Date(System.currentTimeMillis() + getAccessTokenExpireMillis()))
             .signWith(key, SignatureAlgorithm.HS256)
@@ -79,7 +103,7 @@ public class JwtUtil {
 			.build()
 			.parseClaimsJws(token)
 			.getBody()
-			.get("CloverId", Long.class);
+			.get("cloverId", Long.class);
 	}
 
 	public String extractCloverName(String token) {
@@ -88,7 +112,7 @@ public class JwtUtil {
 			.build()
 			.parseClaimsJws(token)
 			.getBody()
-			.get("CloverName", String.class);
+			.get("cloverName", String.class);
 	}
 
     private long getAccessTokenExpireMillis() {
@@ -98,4 +122,14 @@ public class JwtUtil {
     private long getRefreshTokenExpireMillis() {
         return 1000 * 60 * properties.getToken().getRefresh().getMinute();
     }
+
+	public Claims parseClaims(String token) {
+		return Jwts.parserBuilder()
+			.setSigningKey(key)
+			.build()
+			.parseClaimsJws(token)
+			.getBody();
+	}
+
+
 }

--- a/backend/src/main/java/com/example/rabbithell/infrastructure/security/oauth/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/backend/src/main/java/com/example/rabbithell/infrastructure/security/oauth/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,50 @@
+package com.example.rabbithell.infrastructure.security.oauth;
+
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+import com.example.rabbithell.config.CookieUtils;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class HttpCookieOAuth2AuthorizationRequestRepository
+	implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+	private static final String COOKIE_NAME = "OAUTH2_AUTH_REQUEST";
+
+	@Override
+	public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+		try {
+			return CookieUtils.getCookie(request, COOKIE_NAME)
+				.map(cookie -> CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class))
+				.orElse(null);
+		} catch (Exception e) {
+			log.warn("쿠키 역직렬화 실패: {}", e.getMessage());
+			return null;
+		}
+	}
+
+	@Override
+	public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest,
+		HttpServletRequest request, HttpServletResponse response) {
+		if (authorizationRequest == null) {
+			CookieUtils.deleteCookie(request, response, COOKIE_NAME);
+			return;
+		}
+		CookieUtils.addCookie(response, COOKIE_NAME,
+			CookieUtils.serialize(authorizationRequest), 180);
+	}
+
+	@Override
+	public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
+		HttpServletResponse response) {
+		OAuth2AuthorizationRequest authorizationRequest = loadAuthorizationRequest(request);
+		CookieUtils.deleteCookie(request, response, COOKIE_NAME);
+		return authorizationRequest;
+	}
+}

--- a/backend/src/main/java/com/example/rabbithell/infrastructure/security/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/backend/src/main/java/com/example/rabbithell/infrastructure/security/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,68 @@
+package com.example.rabbithell.infrastructure.security.oauth.handler;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import com.example.rabbithell.infrastructure.security.jwt.JwtUtil;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+	private final JwtUtil jwtUtil;
+
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) throws IOException, ServletException {
+
+		log.info("OAuth2 로그인 성공: {}", authentication.getName());
+
+		try {
+			String userId = authentication.getName();
+			String role = authentication.getAuthorities().iterator().next().getAuthority().replace("ROLE_", "");
+
+			log.info("userId={}, role={}", userId, role);
+
+			String miniToken = jwtUtil.createMiniToken(Long.parseLong(userId), role);
+			String redirectUrl = "http://localhost:3000/oauth/success?miniToken=" + miniToken;
+
+			log.info("리다이렉트 URL: {}", redirectUrl);
+			response.sendRedirect(redirectUrl);
+		} catch (Exception e) {
+			log.error("OAuth2 Success 핸들러 중 오류 발생", e);
+			response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "OAuth2 로그인 처리 중 오류 발생");
+		}
+
+		// String userId = authentication.getName();
+		//
+		// Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+		// String role = authorities.iterator().next().getAuthority().replace("ROLE_", "");
+		//
+		// String miniToken = jwtUtil.createMiniToken(Long.parseLong(userId), role);
+		//
+		// response.setContentType("application/json");
+		// response.setCharacterEncoding("UTF-8");
+		//
+		// String body = """
+        //     {
+        //         "success": true,
+        //         "message": "카카오 로그인 성공",
+        //         "miniToken": "%s"
+        //     }
+        //     """.formatted(miniToken);
+		//
+		// response.getWriter().write(body);
+	}
+}

--- a/backend/src/main/java/com/example/rabbithell/infrastructure/security/oauth/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/example/rabbithell/infrastructure/security/oauth/service/CustomOAuth2UserService.java
@@ -1,0 +1,52 @@
+package com.example.rabbithell.infrastructure.security.oauth.service;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import com.example.rabbithell.domain.user.model.User;
+import com.example.rabbithell.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+	private final UserRepository userRepository;
+
+	@Override
+	public OAuth2User loadUser(OAuth2UserRequest request) throws OAuth2AuthenticationException {
+
+		OAuth2User oAuth2User = new DefaultOAuth2UserService().loadUser(request);
+
+		Map<String, Object> kakaoAccount = (Map<String, Object>) oAuth2User.getAttributes().get("kakao_account");
+
+		String email = (String) kakaoAccount.get("email");
+
+		User user = userRepository.findByEmailAndIsDeletedFalse(email)
+			.orElseGet(() -> userRepository.saveAndFlush(
+				User.builder()
+				.name("TEMP")
+				.email(email)
+				.password("KAKAO")
+				.role(User.Role.USER)
+				.isDeleted(false)
+				.build()));
+
+
+		return new DefaultOAuth2User(
+			List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name())),
+			Map.of("userId", user.getId().toString()),
+			"userId"
+		);
+	}
+}

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -45,12 +45,13 @@ spring:
                     kakao:
                         client-id: ${KAKAO_CLIENT_ID}
                         client-secret: ${KAKAO_CLIENT_SECRET}
-                        redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
+                        redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
                         authorization-grant-type: authorization_code
                         scope:
                             - profile_nickname
                             - account_email
                         client-name: kakao
+                        client-authentication-method: client_secret_post
                 provider:
                     kakao:
                         authorization-uri: https://kauth.kakao.com/oauth/authorize


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #66 

## ✨ 변경 사항
- 카카오 인증시 mini토큰 발급: 어드민 12시간, 유저 5분 제한
- 차후 목표
1. 프론트 완료 - 로그인 파트
2. 카카오 인증시 라동으로 클로버 생성 페이지로 리다이렉트 설정 어드민의 경우 miniAuthUser로 권한 확인
게임 플레이는 기존과 같이 AuthUser로 채킹

## 📷 Postman
![image](https://github.com/user-attachments/assets/a3856763-acfe-4131-be09-64d45e478334)
![image](https://github.com/user-attachments/assets/59808e1b-9c53-4138-8821-e635f897d730)

## ✅ 체크리스트
- [ ] 관련 이슈에 연결됨
- [ ] 기능이 정상적으로 동작함
- [ ] 코드 리뷰를 받았음
- [ ] 불필요한 로그/코드 제거됨

## 💬 기타 참고 사항
- 테스트 방법, 추가 설명 등 필요한 경우 작성해 주세요.
