### PR TITLE
Feat/item: 인벤토리 엔티티 변경 및 API 추가

### DIFF
--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/controller/InventoryController.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/controller/InventoryController.java
@@ -3,6 +3,7 @@ package com.example.rabbithell.domain.inventory.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.rabbithell.common.response.CommonResponse;
 import com.example.rabbithell.domain.auth.domain.AuthUser;
+import com.example.rabbithell.domain.inventory.dto.response.EquipResponse;
 import com.example.rabbithell.domain.inventory.dto.response.InventoryResponse;
 import com.example.rabbithell.domain.inventory.service.InventoryService;
 
@@ -32,6 +34,19 @@ public class InventoryController {
 			HttpStatus.OK.value(),
 			"인벤토리 확장 성공",
 			inventoryService.expandInventory(authUser.getUserId(), amount)
+		));
+	}
+
+	@GetMapping("/equipped")
+	public ResponseEntity<CommonResponse<EquipResponse>> getEquippedItemsByCharacter(
+		@AuthenticationPrincipal AuthUser authUser,
+		@RequestParam Long characterId
+	) {
+		return ResponseEntity.ok(CommonResponse.of(
+			true,
+			HttpStatus.OK.value(),
+			"캐릭터 장착 아이템 조회 성공",
+			inventoryService.getEquippedItemsByCharacter(authUser.getUserId(), characterId)
 		));
 	}
 

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/controller/InventoryItemController.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/controller/InventoryItemController.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -100,6 +101,20 @@ public class InventoryItemController {
 			HttpStatus.OK.value(),
 			"인벤토리 아이템 사용 성공",
 			inventoryItemService.useItem(authUser.getUserId(), inventoryItemId, useRequest)
+		));
+	}
+
+	@DeleteMapping("/{inventoryItemId}/discard")
+	public ResponseEntity<CommonResponse<Void>> discardItem(
+		@AuthenticationPrincipal AuthUser authUser,
+		@PathVariable Long inventoryItemId
+	) {
+		inventoryItemService.discardItem(authUser.getUserId(), inventoryItemId);
+
+		return ResponseEntity.ok(CommonResponse.of(
+			true,
+			HttpStatus.OK.value(),
+			"인벤토리 아이템 버리기 성공"
 		));
 	}
 

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/entity/Inventory.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/entity/Inventory.java
@@ -2,6 +2,7 @@ package com.example.rabbithell.domain.inventory.entity;
 
 import static com.example.rabbithell.domain.inventory.exception.code.InventoryExceptionCode.*;
 
+import com.example.rabbithell.domain.clover.entity.Clover;
 import com.example.rabbithell.domain.inventory.exception.InventoryException;
 import com.example.rabbithell.domain.user.model.User;
 
@@ -32,8 +33,8 @@ public class Inventory {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "user_id", nullable = false)
-	private User user;
+	@JoinColumn(name = "clover_id", nullable = false)
+	private Clover clover;
 
 	@Column(nullable = false)
 	private Integer capacity; // 용량

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/exception/code/InventoryExceptionCode.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/exception/code/InventoryExceptionCode.java
@@ -10,7 +10,8 @@ import lombok.RequiredArgsConstructor;
 public enum InventoryExceptionCode {
 
 	USER_MISMATCH(false, HttpStatus.BAD_REQUEST, "나의 인벤토리가 아닙니다."),
-	AMOUNT_TOO_SMALL(false, HttpStatus.BAD_REQUEST, "용량 증가는 1 이상이어야 합니다.");
+	AMOUNT_TOO_SMALL(false, HttpStatus.BAD_REQUEST, "용량 증가는 1 이상이어야 합니다."),
+	INVENTORY_NOT_FOUND(false, HttpStatus.BAD_REQUEST, "인벤토리를 찾을 수 없습니다.");
 
 	private final boolean success;
 	private final HttpStatus status;

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/repository/InventoryRepository.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/repository/InventoryRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.example.rabbithell.domain.clover.entity.Clover;
 import com.example.rabbithell.domain.inventory.entity.Inventory;
 import com.example.rabbithell.domain.inventory.exception.InventoryException;
 
@@ -15,10 +16,10 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long> {
 		return findById(id).orElseThrow(() -> new InventoryException(USER_MISMATCH));
 	}
 
-	Optional<Inventory> findByUserId(Long userId);
+	Optional<Inventory> findByClover(Clover clover);
 
-	default Inventory findByUserIdOrElseThrow(Long userId) {
-		return findByUserId(userId).orElseThrow(() -> new InventoryException(USER_MISMATCH));
+	default Inventory findByCloverOrElseThrow(Clover clover) {
+		return findByClover(clover).orElseThrow(() -> new InventoryException(INVENTORY_NOT_FOUND));
 	}
 
 }

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryItemService.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryItemService.java
@@ -22,4 +22,6 @@ public interface InventoryItemService {
 
 	UseResponse useItem(Long userId, Long inventoryItemId, UseRequest useRequest);
 
+	void discardItem(Long userId, Long inventoryItemId);
+
 }

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryItemServiceImpl.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryItemServiceImpl.java
@@ -85,7 +85,7 @@ public class InventoryItemServiceImpl implements InventoryItemService {
 	@Transactional
 	@Override
 	public UseResponse useItem(Long userId, Long inventoryItemId, UseRequest useRequest) {
-		// 인벤토리 아이템 조회
+		// 인벤토리 아이템 조회 및 유저 검증
 		InventoryItem inventoryItem = inventoryItemRepository.findByIdAndValidateOwner(inventoryItemId, userId);
 
 		// 아이템 타입 체크
@@ -104,6 +104,16 @@ public class InventoryItemServiceImpl implements InventoryItemService {
 
 		// 응답은 사용한 아이템
 		return UseResponse.fromEntity(inventoryItem);
+	}
+
+	@Transactional
+	@Override
+	public void discardItem(Long userId, Long inventoryItemId) {
+		// 인벤토리 아이템 조회 및 유저 검증
+		InventoryItem inventoryItem = inventoryItemRepository.findByIdAndValidateOwner(inventoryItemId, userId);
+
+		// 인벤토리 아이템 삭제
+		inventoryItemRepository.delete(inventoryItem);
 	}
 
 }

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryService.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryService.java
@@ -1,9 +1,12 @@
 package com.example.rabbithell.domain.inventory.service;
 
+import com.example.rabbithell.domain.inventory.dto.response.EquipResponse;
 import com.example.rabbithell.domain.inventory.dto.response.InventoryResponse;
 
 public interface InventoryService {
 
 	InventoryResponse expandInventory(Long userId, int amount);
+
+	EquipResponse getEquippedItemsByCharacter(Long userId, Long characterId);
 
 }

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryServiceImpl.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryServiceImpl.java
@@ -3,8 +3,12 @@ package com.example.rabbithell.domain.inventory.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.rabbithell.domain.character.entity.GameCharacter;
+import com.example.rabbithell.domain.character.repository.CharacterRepository;
+import com.example.rabbithell.domain.inventory.dto.response.EquipResponse;
 import com.example.rabbithell.domain.inventory.dto.response.InventoryResponse;
 import com.example.rabbithell.domain.inventory.entity.Inventory;
+import com.example.rabbithell.domain.inventory.repository.InventoryItemRepository;
 import com.example.rabbithell.domain.inventory.repository.InventoryRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -14,6 +18,8 @@ import lombok.RequiredArgsConstructor;
 public class InventoryServiceImpl implements InventoryService {
 
 	private final InventoryRepository inventoryRepository;
+	private final InventoryItemRepository inventoryItemRepository;
+	private final CharacterRepository characterRepository;
 
 	@Transactional
 	@Override
@@ -26,6 +32,15 @@ public class InventoryServiceImpl implements InventoryService {
 		inventory.expand(amount);
 
 		return InventoryResponse.fromEntity(inventory);
+	}
+
+	@Override
+	public EquipResponse getEquippedItemsByCharacter(Long userId, Long characterId) {
+		// 현재 로그인한 유저의 캐릭터가 맞는지 검증
+		characterRepository.validateOwner(characterId, userId);
+
+		// 캐릭터가 장착한 아이템 반환
+		return inventoryItemRepository.findEquipmentStatusByCharacterId(characterId);
 	}
 
 }

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryServiceImpl.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryServiceImpl.java
@@ -3,8 +3,9 @@ package com.example.rabbithell.domain.inventory.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.example.rabbithell.domain.character.entity.GameCharacter;
 import com.example.rabbithell.domain.character.repository.CharacterRepository;
+import com.example.rabbithell.domain.clover.entity.Clover;
+import com.example.rabbithell.domain.clover.repository.CloverRepository;
 import com.example.rabbithell.domain.inventory.dto.response.EquipResponse;
 import com.example.rabbithell.domain.inventory.dto.response.InventoryResponse;
 import com.example.rabbithell.domain.inventory.entity.Inventory;
@@ -20,11 +21,14 @@ public class InventoryServiceImpl implements InventoryService {
 	private final InventoryRepository inventoryRepository;
 	private final InventoryItemRepository inventoryItemRepository;
 	private final CharacterRepository characterRepository;
+	private final CloverRepository cloverRepository;
 
 	@Transactional
 	@Override
 	public InventoryResponse expandInventory(Long userId, int amount) {
-		Inventory inventory = inventoryRepository.findByIdOrElseThrow(userId);
+		Clover clover = cloverRepository.findByUserIdOrElseThrow(userId);
+
+		Inventory inventory = inventoryRepository.findByCloverOrElseThrow(clover);
 
 		// TODO: 골드 소모
 

--- a/backend/src/main/java/com/example/rabbithell/domain/item/dto/request/ItemRequest.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/item/dto/request/ItemRequest.java
@@ -16,11 +16,25 @@ public record ItemRequest(
 	@Schema(description = "타입", example = "SWORD")
 	ItemType itemType,
 
-	@Schema(description = "희귀도", example = "1")
+	@Schema(description = "희귀도", example = "LEGENDARY")
 	Rarity rarity,
+
+	@Schema(description = "가격", example = "150000")
 	Long price,
-	Long attack,
+
+	@Schema(description = "위력", example = "900")
+	Long power,
+
+	@Schema(description = "최대 위력", example = "1000")
+	Long maxPower,
+
+	@Schema(description = "최소 위력", example = "800")
+	Long minPower,
+
+	@Schema(description = "무게", example = "15")
 	Long weight,
+
+	@Schema(description = "내구도", example = "1000")
 	Integer durability
 ) {
 }

--- a/backend/src/main/java/com/example/rabbithell/domain/item/dto/response/ItemResponse.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/item/dto/response/ItemResponse.java
@@ -20,7 +20,7 @@ public record ItemResponse(
 			item.getName(),
 			item.getRarity(),
 			item.getPrice(),
-			item.getAttack(),
+			item.getPower(),
 			item.getWeight(),
 			item.getDurability()
 		);

--- a/backend/src/main/java/com/example/rabbithell/domain/item/entity/Item.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/item/entity/Item.java
@@ -44,11 +44,15 @@ public class Item extends BaseEntity {
 	private ItemType itemType;
 
 	@Enumerated(EnumType.STRING)
-	private Rarity rarity; // enum
+	private Rarity rarity;
 
 	private Long price;
 
-	private Long attack;
+	private Long power; // 아이템 위력
+
+	private Long maxPower;
+
+	private Long minPower;
 
 	private Long weight;
 
@@ -64,7 +68,9 @@ public class Item extends BaseEntity {
 		ItemType itemType,
 		Rarity rarity,
 		Long price,
-		Long attack,
+		Long power,
+		Long maxPower,
+		Long minPower,
 		Long weight,
 		Integer durability
 	) {
@@ -73,7 +79,9 @@ public class Item extends BaseEntity {
 		this.itemType = itemType;
 		this.rarity = rarity;
 		this.price = price;
-		this.attack = attack;
+		this.power = power;
+		this.maxPower = maxPower;
+		this.minPower = minPower;
 		this.weight = weight;
 		this.durability = durability;
 	}

--- a/backend/src/main/java/com/example/rabbithell/domain/item/service/ItemServiceImpl.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/item/service/ItemServiceImpl.java
@@ -34,7 +34,9 @@ public class ItemServiceImpl implements ItemService {
 			.itemType(itemRequest.itemType())
 			.rarity(itemRequest.rarity())
 			.price(itemRequest.price())
-			.attack(itemRequest.attack())
+			.power(itemRequest.power())
+			.maxPower(itemRequest.maxPower())
+			.minPower(itemRequest.minPower())
 			.weight(itemRequest.weight())
 			.durability(itemRequest.durability())
 			.build();
@@ -74,7 +76,9 @@ public class ItemServiceImpl implements ItemService {
 			itemRequest.itemType(),
 			itemRequest.rarity(),
 			itemRequest.price(),
-			itemRequest.attack(),
+			itemRequest.power(),
+			itemRequest.maxPower(),
+			itemRequest.minPower(),
 			itemRequest.weight(),
 			itemRequest.durability()
 		);


### PR DESCRIPTION
## 📌 관련 이슈
- Resolving #79

## ✨ 변경 사항
- `Item` 엔티티에 최대/최소 위력(`maxPower`/`minPower`) 추가
- 캐릭터 장착 장비 조회 API 추가(`/inventory?characterId=1`)
- 인벤토리 아이템 버리기 API 추가(`/inventory/inventory-items/{inventoryItemId}/discard`)
- `Inventory` 엔티티 연관 관계를 `User`에서 `Clover`로 변경
- 인벤토리 확장 로직을 `Clover` 연관 관계에 맞게 수정

## 📷 Postman
- 이미지 첨부

## ✅ 체크리스트
- [x] 관련 이슈에 연결됨
- [ ] 기능이 정상적으로 동작함
- [ ] 코드 리뷰를 받았음
- [x] 불필요한 로그/코드 제거됨

## 💬 기타 참고 사항
- 테스트 방법, 추가 설명 등 필요한 경우 작성해 주세요.
