### PR TITLE
Feat/item: 아이템 장착 기능 수정 등

### DIFF
--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/controller/InventoryItemController.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/controller/InventoryItemController.java
@@ -51,7 +51,7 @@ public class InventoryItemController {
 	}
 
 	@GetMapping
-	public ResponseEntity<CommonResponse<PageResponse<InventoryItemResponse>>> getAllInventoryItems(
+	public ResponseEntity<CommonResponse<PageResponse<InventoryItemResponse>>> getAllInventoryItemsBySlot(
 		@AuthenticationPrincipal AuthUser authUser,
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "10") int size,
@@ -68,7 +68,7 @@ public class InventoryItemController {
 	}
 
 	@GetMapping("/equipable")
-	public ResponseEntity<CommonResponse<PageResponse<EquipableItemResponse>>> getAllEquipableInventoryItems(
+	public ResponseEntity<CommonResponse<PageResponse<EquipableItemResponse>>> getAllEquipableInventoryItemsBySlot(
 		@AuthenticationPrincipal AuthUser authUser,
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "10") int size,
@@ -79,8 +79,8 @@ public class InventoryItemController {
 		return ResponseEntity.ok(CommonResponse.of(
 			true,
 			HttpStatus.OK.value(),
-			"장착 가능한 인벤토리 아이템 전체 조회 성공",
-			inventoryItemService.getAllEquipableInventoryItems(authUser.getUserId(), pageable)
+			"(슬롯 별) 장착 가능한 인벤토리 아이템 전체 조회 성공",
+			inventoryItemService.getAllEquipableInventoryItems(authUser.getUserId(), slot, pageable)
 		));
 	}
 

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/dto/response/EquipableItemResponse.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/dto/response/EquipableItemResponse.java
@@ -1,15 +1,40 @@
 package com.example.rabbithell.domain.inventory.dto.response;
 
 import com.example.rabbithell.domain.inventory.entity.InventoryItem;
+import com.example.rabbithell.domain.inventory.enums.Slot;
+import com.example.rabbithell.domain.item.enums.ItemType;
+import com.example.rabbithell.domain.item.enums.Rarity;
 
 public record EquipableItemResponse(
+	Long inventoryItemId,
+	Long inventoryId,
 	Long itemId,
-	String name
+	String itemName,
+	String description,
+	ItemType itemType,
+	Rarity rarity,
+	Long price,
+	Long power,
+	Long weight,
+	Integer maxDurability,
+	Integer durability,
+	Slot slot
 ) {
 	public static EquipableItemResponse fromEntity(InventoryItem inventoryItem) {
 		return new EquipableItemResponse(
+			inventoryItem.getId(),
+			inventoryItem.getInventory().getId(),
 			inventoryItem.getItem().getId(),
-			inventoryItem.getItem().getName()
+			inventoryItem.getItem().getName(),
+			inventoryItem.getItem().getDescription(),
+			inventoryItem.getItem().getItemType(),
+			inventoryItem.getItem().getRarity(),
+			inventoryItem.getItem().getPrice(),
+			inventoryItem.getItem().getPower(),
+			inventoryItem.getItem().getWeight(),
+			inventoryItem.getItem().getDurability(),
+			inventoryItem.getDurability(),
+			inventoryItem.getSlot()
 		);
 	}
 }

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/dto/response/EquippedItem.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/dto/response/EquippedItem.java
@@ -11,8 +11,9 @@ public record EquippedItem(
 	String characterName,
 	String description,
 	Long power,
-	Slot slot,
-	Integer durability
+	Integer maxDurability,
+	Integer durability,
+	Slot slot
 ) {
 	public static EquippedItem fromEntity(InventoryItem inventoryItem) {
 		return new EquippedItem(
@@ -23,8 +24,9 @@ public record EquippedItem(
 			inventoryItem.getCharacter().getName(),
 			inventoryItem.getItem().getDescription(),
 			inventoryItem.getItem().getPower(),
-			inventoryItem.getSlot(),
-			inventoryItem.getDurability()
+			inventoryItem.getItem().getDurability(),
+			inventoryItem.getDurability(),
+			inventoryItem.getSlot()
 		);
 	}
 }

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/dto/response/InventoryItemResponse.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/dto/response/InventoryItemResponse.java
@@ -6,6 +6,7 @@ import com.example.rabbithell.domain.item.enums.ItemType;
 import com.example.rabbithell.domain.item.enums.Rarity;
 
 public record InventoryItemResponse(
+	Long inventoryItemId,
 	Long inventoryId,
 	Long itemId,
 	String itemName,
@@ -21,6 +22,7 @@ public record InventoryItemResponse(
 ) {
 	public static InventoryItemResponse fromEntity(InventoryItem inventoryItem) {
 		return new InventoryItemResponse(
+			inventoryItem.getId(),
 			inventoryItem.getInventory().getId(),
 			inventoryItem.getItem().getId(),
 			inventoryItem.getItem().getName(),

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/entity/InventoryItem.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/entity/InventoryItem.java
@@ -4,7 +4,6 @@ import com.example.rabbithell.common.audit.BaseEntity;
 import com.example.rabbithell.domain.character.entity.GameCharacter;
 import com.example.rabbithell.domain.inventory.enums.Slot;
 import com.example.rabbithell.domain.item.entity.Item;
-import com.example.rabbithell.domain.item.enums.ItemType;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -16,7 +15,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -42,7 +40,7 @@ public class InventoryItem extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "game_character_id")
 	private GameCharacter character; // 장착 캐릭터
-	
+
 	private Long power; // Item 엔티티의 maxPower와 minPower 사이
 
 	private Integer durability;

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/entity/InventoryItem.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/entity/InventoryItem.java
@@ -4,6 +4,7 @@ import com.example.rabbithell.common.audit.BaseEntity;
 import com.example.rabbithell.domain.character.entity.GameCharacter;
 import com.example.rabbithell.domain.inventory.enums.Slot;
 import com.example.rabbithell.domain.item.entity.Item;
+import com.example.rabbithell.domain.item.enums.ItemType;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -56,10 +57,9 @@ public class InventoryItem extends BaseEntity {
 		this.slot = slot;
 	}
 
-	// TODO: 아이템 종류에 따라 장착 부위가 정해지도록 기능 수정 필요
-	public void equip(GameCharacter character, Slot slot) {
+	public void equip(GameCharacter character) {
 		this.character = character;
-		this.slot = slot;
+		this.slot = Slot.getSlotByItemType(this.getItem().getItemType());
 	}
 
 	public void unequip() {

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/entity/InventoryItem.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/entity/InventoryItem.java
@@ -42,6 +42,8 @@ public class InventoryItem extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "game_character_id")
 	private GameCharacter character; // 장착 캐릭터
+	
+	private Long power; // Item 엔티티의 maxPower와 minPower 사이
 
 	private Integer durability;
 

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/enums/Slot.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/enums/Slot.java
@@ -1,5 +1,24 @@
 package com.example.rabbithell.domain.inventory.enums;
 
+import java.util.List;
+
+import com.example.rabbithell.domain.item.enums.ItemType;
+
 public enum Slot {
-	HEAD, BODY, HAND
+	HEAD, BODY, HAND;
+
+	public static Slot getSlotByItemType(ItemType itemType) {
+		if (itemType == null) {
+			return null;
+		}
+
+		for (Slot slot : Slot.values()) {
+			List<ItemType> types = ItemType.getItemTypeBySlot(slot);
+			if (types != null && types.contains(itemType)) {
+				return slot;
+			}
+		}
+
+		return null; // 해당하는 슬롯이 없을 경우
+	}
 }

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/repository/InventoryItemQueryRepository.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/repository/InventoryItemQueryRepository.java
@@ -1,9 +1,17 @@
 package com.example.rabbithell.domain.inventory.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import com.example.rabbithell.domain.inventory.dto.response.EquipResponse;
+import com.example.rabbithell.domain.inventory.entity.Inventory;
+import com.example.rabbithell.domain.inventory.entity.InventoryItem;
+import com.example.rabbithell.domain.inventory.enums.Slot;
 
 public interface InventoryItemQueryRepository {
 
-	EquipResponse findEquipmentStatusByCharacterId(Long characterId);
+	EquipResponse findEquipmentStatusByCharacter(Long characterId);
+
+	Page<InventoryItem> findEquipableItemBySlot(Inventory inventory, Slot slot, Pageable pageable);
 
 }

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/repository/InventoryItemQueryRepository.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/repository/InventoryItemQueryRepository.java
@@ -14,4 +14,6 @@ public interface InventoryItemQueryRepository {
 
 	Page<InventoryItem> findEquipableItemBySlot(Inventory inventory, Slot slot, Pageable pageable);
 
+	Long findByCharacterAndSlot(Long characterId, Slot slot);
+
 }

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/repository/InventoryItemQueryRepositoryImpl.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/repository/InventoryItemQueryRepositoryImpl.java
@@ -110,7 +110,7 @@ public class InventoryItemQueryRepositoryImpl implements InventoryItemQueryRepos
 	public Long findByCharacterAndSlot(Long characterId, Slot slot) {
 		QInventoryItem inventoryItem = QInventoryItem.inventoryItem;
 
-		Long inventoryItemId = queryFactory
+		return queryFactory
 			.select(inventoryItem.id)
 			.from(inventoryItem)
 			.where(
@@ -118,8 +118,6 @@ public class InventoryItemQueryRepositoryImpl implements InventoryItemQueryRepos
 				inventoryItem.slot.eq(slot)
 			)
 			.fetchFirst();
-
-		return inventoryItemId;
 	}
 
 }

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/repository/InventoryItemQueryRepositoryImpl.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/repository/InventoryItemQueryRepositoryImpl.java
@@ -49,8 +49,9 @@ public class InventoryItemQueryRepositoryImpl implements InventoryItemQueryRepos
 				t.get(inventoryItem.character.name),
 				t.get(inventoryItem.item.description),
 				t.get(inventoryItem.item.power),
-				t.get(inventoryItem.slot),
-				t.get(inventoryItem.durability)
+				t.get(inventoryItem.item.durability),
+				t.get(inventoryItem.durability),
+				t.get(inventoryItem.slot)
 			))
 			.toList();
 
@@ -101,4 +102,5 @@ public class InventoryItemQueryRepositoryImpl implements InventoryItemQueryRepos
 	private BooleanExpression itemTypeIn(QItem item, List<ItemType> itemTypes) {
 		return (itemTypes != null && !itemTypes.isEmpty()) ? item.itemType.in(itemTypes) : null;
 	}
+
 }

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/repository/InventoryItemQueryRepositoryImpl.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/repository/InventoryItemQueryRepositoryImpl.java
@@ -28,6 +28,7 @@ public class InventoryItemQueryRepositoryImpl implements InventoryItemQueryRepos
 
 	private final JPAQueryFactory queryFactory;
 
+	// 해당 캐릭터의 장비 장착 현황 조회
 	@Override
 	public EquipResponse findEquipmentStatusByCharacter(Long characterId) {
 		QInventoryItem inventoryItem = QInventoryItem.inventoryItem;
@@ -99,8 +100,26 @@ public class InventoryItemQueryRepositoryImpl implements InventoryItemQueryRepos
 		return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
 	}
 
+	// 아이템 타입 동적 조건
 	private BooleanExpression itemTypeIn(QItem item, List<ItemType> itemTypes) {
 		return (itemTypes != null && !itemTypes.isEmpty()) ? item.itemType.in(itemTypes) : null;
+	}
+
+	// 캐릭터가 특정 슬롯에 장착한 아이템 조회
+	@Override
+	public Long findByCharacterAndSlot(Long characterId, Slot slot) {
+		QInventoryItem inventoryItem = QInventoryItem.inventoryItem;
+
+		Long inventoryItemId = queryFactory
+			.select(inventoryItem.id)
+			.from(inventoryItem)
+			.where(
+				inventoryItem.character.id.eq(characterId),
+				inventoryItem.slot.eq(slot)
+			)
+			.fetchFirst();
+
+		return inventoryItemId;
 	}
 
 }

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/repository/InventoryItemQueryRepositoryImpl.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/repository/InventoryItemQueryRepositoryImpl.java
@@ -2,12 +2,22 @@ package com.example.rabbithell.domain.inventory.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 import com.example.rabbithell.domain.inventory.dto.response.EquipResponse;
 import com.example.rabbithell.domain.inventory.dto.response.EquippedItem;
+import com.example.rabbithell.domain.inventory.entity.Inventory;
+import com.example.rabbithell.domain.inventory.entity.InventoryItem;
 import com.example.rabbithell.domain.inventory.entity.QInventoryItem;
+import com.example.rabbithell.domain.inventory.enums.Slot;
+import com.example.rabbithell.domain.item.entity.QItem;
+import com.example.rabbithell.domain.item.enums.ItemType;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -19,7 +29,7 @@ public class InventoryItemQueryRepositoryImpl implements InventoryItemQueryRepos
 	private final JPAQueryFactory queryFactory;
 
 	@Override
-	public EquipResponse findEquipmentStatusByCharacterId(Long characterId) {
+	public EquipResponse findEquipmentStatusByCharacter(Long characterId) {
 		QInventoryItem inventoryItem = QInventoryItem.inventoryItem;
 
 		List<Tuple> tuples = queryFactory
@@ -47,4 +57,48 @@ public class InventoryItemQueryRepositoryImpl implements InventoryItemQueryRepos
 		return new EquipResponse(equippedItems);
 	}
 
+	// 슬롯을 쿼리 파라미터 조건으로 해서 장착 가능한 아이템 리스트 조회
+	@Override
+	public Page<InventoryItem> findEquipableItemBySlot(Inventory inventory, Slot slot, Pageable pageable) {
+		QInventoryItem inventoryItem = QInventoryItem.inventoryItem;
+		QItem item = QItem.item;
+
+		// 조건으로 쓰기 위한 장착 가능한 아이템 타입 리스트
+		List<ItemType> equipableTypes = ItemType.getEquipableTypes();
+
+		// 슬롯 조건
+		List<ItemType> itemTypesBySlot = ItemType.getItemTypeBySlot(slot);
+
+		List<InventoryItem> content = queryFactory
+			.selectFrom(inventoryItem)
+			.join(inventoryItem.item, item).fetchJoin()
+			.where(
+				inventoryItem.inventory.eq(inventory),
+				item.itemType.in(equipableTypes),
+				inventoryItem.character.isNull(),
+				inventoryItem.slot.isNull(),
+				itemTypeIn(item, itemTypesBySlot) // 동적 조건
+			)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		JPAQuery<Long> countQuery = queryFactory
+			.select(inventoryItem.count())
+			.from(inventoryItem)
+			.join(inventoryItem.item, item)
+			.where(
+				inventoryItem.inventory.eq(inventory),
+				item.itemType.in(equipableTypes),
+				inventoryItem.character.isNull(),
+				inventoryItem.slot.isNull(),
+				itemTypeIn(item, itemTypesBySlot) // 동적 조건
+			);
+
+		return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+	}
+
+	private BooleanExpression itemTypeIn(QItem item, List<ItemType> itemTypes) {
+		return (itemTypes != null && !itemTypes.isEmpty()) ? item.itemType.in(itemTypes) : null;
+	}
 }

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/repository/InventoryItemRepository.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/repository/InventoryItemRepository.java
@@ -2,12 +2,14 @@ package com.example.rabbithell.domain.inventory.repository;
 
 import static com.example.rabbithell.domain.inventory.exception.code.InventoryItemExceptionCode.*;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.example.rabbithell.domain.character.entity.GameCharacter;
 import com.example.rabbithell.domain.inventory.entity.Inventory;
 import com.example.rabbithell.domain.inventory.entity.InventoryItem;
 import com.example.rabbithell.domain.inventory.enums.Slot;
@@ -35,4 +37,9 @@ public interface InventoryItemRepository extends JpaRepository<InventoryItem, Lo
 		Pageable pageable);
 
 	List<InventoryItem> findByCharacter_Id(Long characterId);
+
+	Page<InventoryItem> findByInventoryAndItem_ItemTypeInAndSlot(Inventory inventory, Collection<ItemType> itemItemTypes, Slot slot, Pageable pageable);
+
+	Page<InventoryItem> findByInventoryAndItem_ItemTypeInAndSlotAndCharacterIsNullAndSlotIsNull(Inventory inventory, Collection<ItemType> itemItemTypes, Slot slot, GameCharacter character,
+		Slot slot1, Pageable pageable);
 }

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryItemService.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryItemService.java
@@ -21,7 +21,7 @@ public interface InventoryItemService {
 
 	PageResponse<InventoryItemResponse> getAllInventoryItemsFilterBySlot(Long userId, Slot slot, Pageable pageable);
 
-	PageResponse<EquipableItemResponse> getAllEquipableInventoryItems(Long userId, Pageable pageable);
+	PageResponse<EquipableItemResponse> getAllEquipableInventoryItems(Long userId, Slot slot, Pageable pageable);
 
 	EquipResponse getEquippedItemsByCharacter(Long userId, Long characterId);
 

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryItemServiceImpl.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryItemServiceImpl.java
@@ -123,7 +123,7 @@ public class InventoryItemServiceImpl implements InventoryItemService {
 		inventoryItemRepository.findByIdOrElseThrow(equippedItemId).unequip();
 
 		// 아이템 장착
-		inventoryItem.equip(character, equipRequest.slot());
+		inventoryItem.equip(character);
 
 		// 응답은 캐릭터가 장착 중인 모든 아이템
 		return inventoryItemRepository.findEquipmentStatusByCharacter(characterId);

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryItemServiceImpl.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryItemServiceImpl.java
@@ -73,15 +73,11 @@ public class InventoryItemServiceImpl implements InventoryItemService {
 
 	@Transactional(readOnly = true)
 	@Override
-	public PageResponse<EquipableItemResponse> getAllEquipableInventoryItems(Long userId, Pageable pageable) {
+	public PageResponse<EquipableItemResponse> getAllEquipableInventoryItems(Long userId, Slot slot,
+		Pageable pageable) {
 		Inventory inventory = getMyInventory(userId);
 
-		// 조건으로 쓰기 위한 장착 가능한 아이템 타입 리스트
-		List<ItemType> equipableTypes = ItemType.getEquipableTypes();
-
-		// 장착 가능한 인벤토리 아이템만 조회
-		Page<InventoryItem> page = inventoryItemRepository.findByInventoryAndItem_ItemTypeIn(inventory, equipableTypes,
-			pageable);
+		Page<InventoryItem> page = inventoryItemRepository.findEquipableItemBySlot(inventory, slot, pageable);
 
 		// DTO로 매핑
 		List<EquipableItemResponse> dtoList = page.stream()
@@ -98,7 +94,7 @@ public class InventoryItemServiceImpl implements InventoryItemService {
 		// characterRepository.validateOwner(characterId, userId);
 
 		// 캐릭터가 장착한 아이템 반환
-		return inventoryItemRepository.findEquipmentStatusByCharacterId(characterId);
+		return inventoryItemRepository.findEquipmentStatusByCharacter(characterId);
 	}
 
 	@Transactional(readOnly = true)
@@ -125,7 +121,7 @@ public class InventoryItemServiceImpl implements InventoryItemService {
 		inventoryItem.equip(character, equipRequest.slot());
 
 		// 응답은 캐릭터가 장착 중인 모든 아이템
-		return inventoryItemRepository.findEquipmentStatusByCharacterId(characterId);
+		return inventoryItemRepository.findEquipmentStatusByCharacter(characterId);
 	}
 
 	@Transactional

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryItemServiceImpl.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryItemServiceImpl.java
@@ -117,6 +117,11 @@ public class InventoryItemServiceImpl implements InventoryItemService {
 		Long characterId = equipRequest.characterId();
 		GameCharacter character = characterRepository.findByIdOrElseThrow(characterId);
 
+		// 캐릭터가 장착 중인 아이템 조회해서 같은 부위에 아이템이 있으면 그 아이템 장착 해제
+		Slot slot = Slot.getSlotByItemType(inventoryItem.getItem().getItemType());
+		Long equippedItemId = inventoryItemRepository.findByCharacterAndSlot(characterId, slot);
+		inventoryItemRepository.findByIdOrElseThrow(equippedItemId).unequip();
+
 		// 아이템 장착
 		inventoryItem.equip(character, equipRequest.slot());
 

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryService.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryService.java
@@ -1,6 +1,5 @@
 package com.example.rabbithell.domain.inventory.service;
 
-import com.example.rabbithell.domain.inventory.dto.response.EquipResponse;
 import com.example.rabbithell.domain.inventory.dto.response.InventoryResponse;
 
 public interface InventoryService {

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryServiceImpl.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryServiceImpl.java
@@ -6,7 +6,6 @@ import org.springframework.transaction.annotation.Transactional;
 import com.example.rabbithell.domain.character.repository.CharacterRepository;
 import com.example.rabbithell.domain.clover.entity.Clover;
 import com.example.rabbithell.domain.clover.repository.CloverRepository;
-import com.example.rabbithell.domain.inventory.dto.response.EquipResponse;
 import com.example.rabbithell.domain.inventory.dto.response.InventoryResponse;
 import com.example.rabbithell.domain.inventory.entity.Inventory;
 import com.example.rabbithell.domain.inventory.repository.InventoryItemRepository;

--- a/backend/src/main/java/com/example/rabbithell/domain/item/entity/Item.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/item/entity/Item.java
@@ -48,8 +48,6 @@ public class Item extends BaseEntity {
 
 	private Long price;
 
-	private Long power; // 아이템 위력
-
 	private Long maxPower;
 
 	private Long minPower;
@@ -63,7 +61,7 @@ public class Item extends BaseEntity {
 	private boolean isDeleted;
 
 	@Builder
-	public Item(Shop shop, String name, String description, ItemType itemType, Rarity rarity, Long price, Long power,
+	public Item(Shop shop, String name, String description, ItemType itemType, Rarity rarity, Long price,
 		Long maxPower, Long minPower, Long weight, Integer durability, boolean isDeleted) {
 		this.shop = shop;
 		this.name = name;
@@ -71,7 +69,6 @@ public class Item extends BaseEntity {
 		this.itemType = itemType;
 		this.rarity = rarity;
 		this.price = price;
-		this.power = power;
 		this.maxPower = maxPower;
 		this.minPower = minPower;
 		this.weight = weight;
@@ -80,14 +77,13 @@ public class Item extends BaseEntity {
 	}
 
 	public void update(Shop shop, String name, String description, ItemType itemType, Rarity rarity, Long price,
-		Long power, Long maxPower, Long minPower, Long weight, Integer durability) {
+		Long maxPower, Long minPower, Long weight, Integer durability) {
 		this.shop = shop;
 		this.name = name;
 		this.description = description;
 		this.itemType = itemType;
 		this.rarity = rarity;
 		this.price = price;
-		this.power = power;
 		this.maxPower = maxPower;
 		this.minPower = minPower;
 		this.weight = weight;

--- a/backend/src/main/java/com/example/rabbithell/domain/item/enums/ItemType.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/item/enums/ItemType.java
@@ -3,9 +3,11 @@ package com.example.rabbithell.domain.item.enums;
 import java.util.Arrays;
 import java.util.List;
 
+import com.example.rabbithell.domain.inventory.enums.Slot;
+
 public enum ItemType {
 	// equipable
-	SWORD, SHIELD, BOW, DAGGER,
+	SWORD, SHIELD, BOW, DAGGER, CLOTHES, EARRINGS,
 
 	// consumable
 	HP, MP;
@@ -14,6 +16,19 @@ public enum ItemType {
 		return Arrays.stream(values())
 			.filter(ItemType::isEquipable)
 			.toList();
+	}
+
+	public static List<ItemType> getItemTypeBySlot(Slot slot) {
+		if (slot == null) {
+			return null;
+		}
+
+		return switch (slot) {
+			case HEAD -> List.of(EARRINGS);
+			case BODY -> List.of(SHIELD, CLOTHES);
+			case HAND -> List.of(SWORD, BOW, DAGGER);
+			default -> null;
+		};
 	}
 
 	public boolean isEquipable() {


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #79

## ✨ 변경 사항
- 장착 가능한 아이템 리스트에 이미 장착 중인 아이템은 안 보이도록 수정
- 아이템 응답에 필드 추가(설명, 타입 등)
- 아이템 장착 시 동일한 슬롯에 먼저 장착된 아이템은 장착 해제되도록 수정
- 아이템 종류에 따라 장착 부위가 정해지도록 기능 수정(`InventoryItem` > `equip()`)
- 위력(`power`) 필드를 인벤토리 아이템으로 이동

## 📷 Postman
- 이미지 첨부

## ✅ 체크리스트
- [x] 관련 이슈에 연결됨
- [x] 기능이 정상적으로 동작함
- [ ] 코드 리뷰를 받았음
- [x] 불필요한 로그/코드 제거됨

## 💬 기타 참고 사항
- 테스트 방법, 추가 설명 등 필요한 경우 작성해 주세요.
