### PR TITLE
Feat/inventory item/appraise: 아이템 감정 로직 추가

### DIFF
--- a/backend/src/main/java/com/example/rabbithell/common/util/DataInitializer.java
+++ b/backend/src/main/java/com/example/rabbithell/common/util/DataInitializer.java
@@ -258,35 +258,31 @@ public class DataInitializer implements CommandLineRunner {
 		itemRepository.save(slimeBell);
 		itemRepository.save(tuxedo);
 
-		InventoryItem inventoryWeapon1 = new InventoryItem(inventory, weapon, character1, 20L, 100, 100, 3L, Slot.HAND);
-		InventoryItem inventoryArmor1 = new InventoryItem(inventory, armor, character1, 20L, 100, 100, 3L, Slot.BODY);
-		InventoryItem inventoryAccessory1 = new InventoryItem(inventory, accessory, character1, 20L, 100, 100, 3L,
-			Slot.HEAD);
+		InventoryItem inventoryWeapon1 = new InventoryItem(inventory, weapon, character1, 20L, 100, 100, 3L, Slot.HAND, false);
+		InventoryItem inventoryArmor1 = new InventoryItem(inventory, armor, character1, 20L, 100, 100, 3L, Slot.BODY, false);
+		InventoryItem inventoryAccessory1 = new InventoryItem(inventory, accessory, character1, 20L, 100, 100, 3L, Slot.HEAD, false);
 
-		InventoryItem inventoryWeapon2 = new InventoryItem(inventory, weapon, character2, 20L, 100, 100, 3L, Slot.HAND);
-		InventoryItem inventoryArmor2 = new InventoryItem(inventory, armor, character2, 20L, 100, 100, 3L, Slot.BODY);
-		InventoryItem inventoryAccessory2 = new InventoryItem(inventory, accessory, character2, 20L, 100, 100, 3L,
-			Slot.HEAD);
+		InventoryItem inventoryWeapon2 = new InventoryItem(inventory, weapon, character2, 20L, 100, 100, 3L, Slot.HAND, false);
+		InventoryItem inventoryArmor2 = new InventoryItem(inventory, armor, character2, 20L, 100, 100, 3L, Slot.BODY, false);
+		InventoryItem inventoryAccessory2 = new InventoryItem(inventory, accessory, character2, 20L, 100, 100, 3L, Slot.HEAD, false);
 
-		InventoryItem inventoryWeapon3 = new InventoryItem(inventory, weapon, character3, 20L, 100, 100, 3L, Slot.HAND);
-		InventoryItem inventoryArmor3 = new InventoryItem(inventory, armor, character3, 20L, 100, 100, 3L, Slot.BODY);
-		InventoryItem inventoryAccessory3 = new InventoryItem(inventory, accessory, character3, 20L, 100, 100, 3L,
-			Slot.HEAD);
+		InventoryItem inventoryWeapon3 = new InventoryItem(inventory, weapon, character3, 20L, 100, 100, 3L, Slot.HAND, false);
+		InventoryItem inventoryArmor3 = new InventoryItem(inventory, armor, character3, 20L, 100, 100, 3L, Slot.BODY, false);
+		InventoryItem inventoryAccessory3 = new InventoryItem(inventory, accessory, character3, 20L, 100, 100, 3L, Slot.HEAD, false);
 
-		InventoryItem inventoryWeapon4 = new InventoryItem(inventory, weapon, character4, 20L, 100, 100, 3L, Slot.HAND);
-		InventoryItem inventoryArmor4 = new InventoryItem(inventory, armor, character4, 20L, 100, 100, 3L, Slot.BODY);
-		InventoryItem inventoryAccessory4 = new InventoryItem(inventory, accessory, character4, 20L, 100, 100, 3L,
-			Slot.HEAD);
+		InventoryItem inventoryWeapon4 = new InventoryItem(inventory, weapon, character4, 20L, 100, 100, 3L, Slot.HAND, false);
+		InventoryItem inventoryArmor4 = new InventoryItem(inventory, armor, character4, 20L, 100, 100, 3L, Slot.BODY, false);
+		InventoryItem inventoryAccessory4 = new InventoryItem(inventory, accessory, character4, 20L, 100, 100, 3L, Slot.HEAD, false);
 
-		InventoryItem iHpPotion = new InventoryItem(inventory, hpPotion, null, 0L, 10000, 10000, 0L, null);
-		InventoryItem iMpPotion = new InventoryItem(inventory, mpPotion, null, 0L, 10000, 10000, 0L, null);
-		InventoryItem iFeverRemedy = new InventoryItem(inventory, feverRemedy, null, 0L, 10000, 10000, 0L, null);
-		InventoryItem iSomiGun = new InventoryItem(inventory, somiGun, null, 80L, 10000, 10000, 8L, null);
-		InventoryItem iFourCard = new InventoryItem(inventory, fourCard, null, 80L, 10000, 10000, 10L, null);
-		InventoryItem iAirplaneTicket = new InventoryItem(inventory, airplaneTicket, null, 0L, 10000, 10000, 0L, null);
-		InventoryItem iWakeUp = new InventoryItem(inventory, wakeUp, null, 0L, 10000, 10000, 0L, null);
-		InventoryItem iSlimeBell = new InventoryItem(inventory, slimeBell, null, 0L, 10000, 10000, 0L, null);
-		InventoryItem iTuxedo = new InventoryItem(inventory, tuxedo, null, 10L, 10000, 10000, 3L, null);
+		InventoryItem iHpPotion = new InventoryItem(inventory, hpPotion, null, 0L, 10000, 10000, 0L, null, false);
+		InventoryItem iMpPotion = new InventoryItem(inventory, mpPotion, null, 0L, 10000, 10000, 0L, null, false);
+		InventoryItem iFeverRemedy = new InventoryItem(inventory, feverRemedy, null, 0L, 10000, 10000, 0L, null, false);
+		InventoryItem iSomiGun = new InventoryItem(inventory, somiGun, null, 80L, 10000, 10000, 8L, null, false);
+		InventoryItem iFourCard = new InventoryItem(inventory, fourCard, null, 80L, 10000, 10000, 10L, null, false);
+		InventoryItem iAirplaneTicket = new InventoryItem(inventory, airplaneTicket, null, 0L, 10000, 10000, 0L, null, false);
+		InventoryItem iWakeUp = new InventoryItem(inventory, wakeUp, null, 0L, 10000, 10000, 0L, null, false);
+		InventoryItem iSlimeBell = new InventoryItem(inventory, slimeBell, null, 0L, 10000, 10000, 0L, null, false);
+		InventoryItem iTuxedo = new InventoryItem(inventory, tuxedo, null, 10L, 10000, 10000, 3L, null, false);
 
 		inventoryItemRepository.save(inventoryWeapon1);
 		inventoryItemRepository.save(inventoryArmor1);

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/controller/InventoryItemController.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/controller/InventoryItemController.java
@@ -151,4 +151,18 @@ public class InventoryItemController {
 		));
 	}
 
+	// 아이템 감정
+	@PostMapping("/{inventoryItemId}/appraise")
+	public ResponseEntity<CommonResponse<InventoryItemResponse>> appraiseItem(
+		@AuthenticationPrincipal AuthUser authUser,
+		@PathVariable Long inventoryItemId
+	) {
+		return ResponseEntity.ok(CommonResponse.of(
+			true,
+			HttpStatus.OK.value(),
+			"인벤토리 아이템 감정 성공",
+			inventoryItemService.appraiseItem(authUser.getUserId(), inventoryItemId)
+		));
+	}
+
 }

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/entity/InventoryItem.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/entity/InventoryItem.java
@@ -43,7 +43,7 @@ public class InventoryItem extends BaseEntity {
 
 	private Long power; // Item 엔티티의 maxPower와 minPower 사이
 
-	private Integer maxDurability;
+	private Integer maxDurability; // 초기값은 Item 엔티티의 maxDurability -> 수리 실패 시 점점 줄어듦
 
 	private Integer durability;
 
@@ -52,9 +52,11 @@ public class InventoryItem extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	private Slot slot; // 장착 부위
 
+	private Boolean isHidden;
+
 	@Builder
 	public InventoryItem(Inventory inventory, Item item, GameCharacter character, Long power, Integer maxDurability,
-		Integer durability, Long weight, Slot slot) {
+		Integer durability, Long weight, Slot slot, Boolean isHidden) {
 		this.inventory = inventory;
 		this.item = item;
 		this.character = character;
@@ -63,6 +65,7 @@ public class InventoryItem extends BaseEntity {
 		this.durability = durability;
 		this.weight = weight;
 		this.slot = slot;
+		this.isHidden = isHidden;
 	}
 
 	public InventoryItem(Inventory inventory, Item item) {
@@ -76,7 +79,7 @@ public class InventoryItem extends BaseEntity {
 
 	public void equip(GameCharacter character) {
 		this.character = character;
-		this.slot = Slot.getSlotByItemType(this.getItem().getItemType());
+		this.slot = Slot.getSlotByItemType(item.getItemType());
 	}
 
 	public void unequip() {
@@ -87,6 +90,12 @@ public class InventoryItem extends BaseEntity {
 	// TODO: 나중에 기능 수정 필요: 내구도 닳는 양 필요
 	public void use(int amount) {
 		this.durability -= amount;
+	}
+
+	public void appraise(Long power, Long weight) {
+		this.power = power;
+		this.weight = weight;
+		this.isHidden = false;
 	}
 
 }

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/exception/code/InventoryItemExceptionCode.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/exception/code/InventoryItemExceptionCode.java
@@ -12,7 +12,8 @@ public enum InventoryItemExceptionCode {
 	INVENTORY_ITEM_NOT_FOUND(false, HttpStatus.NOT_FOUND, "아이템이 존재하지 않습니다."),
 	USER_MISMATCH(false, HttpStatus.BAD_REQUEST, "나의 아이템이 아닙니다."),
 	NOT_CONSUMABLE(false, HttpStatus.BAD_REQUEST, "사용 가능한 아이템이 아닙니다."),
-	NOT_ENOUGH_DURABILITY(false, HttpStatus.BAD_REQUEST, "내구도가 부족합니다.");
+	NOT_ENOUGH_DURABILITY(false, HttpStatus.BAD_REQUEST, "내구도가 부족합니다."),
+	NOT_HIDDEN(false, HttpStatus.BAD_REQUEST, "감정이 필요없는 아이템입니다.");
 
 	private final boolean success;
 	private final HttpStatus status;

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryItemService.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryItemService.java
@@ -37,4 +37,6 @@ public interface InventoryItemService {
 
 	void discardItem(Long userId, Long inventoryItemId);
 
+	InventoryItemResponse appraiseItem(Long userId, Long inventoryItemId);
+
 }

--- a/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryItemServiceImpl.java
+++ b/backend/src/main/java/com/example/rabbithell/domain/inventory/service/InventoryItemServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.rabbithell.domain.inventory.service;
 import static com.example.rabbithell.domain.inventory.exception.code.InventoryItemExceptionCode.*;
 
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -180,6 +181,37 @@ public class InventoryItemServiceImpl implements InventoryItemService {
 
 		// 인벤토리 아이템 삭제
 		inventoryItemRepository.delete(inventoryItem);
+	}
+
+	@Transactional
+	@Override
+	public InventoryItemResponse appraiseItem(Long userId, Long inventoryItemId) {
+		// 인벤토리 아이템 조회 및 유저 검증
+		InventoryItem inventoryItem = inventoryItemRepository.findByIdAndValidateOwner(inventoryItemId, userId);
+
+		// 아이템이 숨겨진 상태가 아니면 예외 발생
+		if (!inventoryItem.getIsHidden()) {
+			throw new InventoryItemException(NOT_HIDDEN);
+		}
+
+		// 아이템 감정 로직 시작
+		Item item = inventoryItem.getItem();
+		Long minPower = item.getMinPower();
+		Long maxPower = item.getMaxPower();
+		Long minWeight = item.getMinWeight();
+		Long maxWeight = item.getMaxWeight();
+
+		double random = ThreadLocalRandom.current().nextDouble(); // 0.0 ~ 1.0 사이
+		double skewedToMin = Math.pow(random, 2); // 낮은 값이 나올 확률이 높게 조정
+		Long power = minPower + (long) ((maxPower - minPower + 1) * skewedToMin);
+
+		random = ThreadLocalRandom.current().nextDouble();
+		double skewedToMax = Math.pow(random, 0.5); // 높은 값이 나올 확률이 높게 조정
+		Long weight = minWeight + (long) ((maxWeight - minWeight + 1) * skewedToMax);
+
+		// 아이템 스탯 확정
+		inventoryItem.appraise(power, weight);
+		return InventoryItemResponse.fromEntity(inventoryItem);
 	}
 
 	// 나의 인벤토리 조회


### PR DESCRIPTION
## 📌 관련 이슈
- 없음

## ✨ 변경 사항
- `InventoryItem` 엔티티에 `isHidden` 필드 추가
  - `LEGENDARY` 이상 아이템은 무조건 숨겨지도록 설정 필요
- `InventoryItemService`: 아이템 감정 로직 추가
- `DataInitiazlier`:  아이템 감정 로직 추가에 따른 데이터 변경

## 📷 Postman
- 이미지 첨부

## ✅ 체크리스트
- [ ] 관련 이슈에 연결됨
- [x] 기능이 정상적으로 동작함
- [ ] 코드 리뷰를 받았음
- [x] 불필요한 로그/코드 제거됨

## 💬 기타 참고 사항
- 테스트 방법, 추가 설명 등 필요한 경우 작성해 주세요.
